### PR TITLE
Update code of conduct link to a real link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Code of Conduct
 
 Facebook has adopted a Code of Conduct that we expect project participants to adhere to.
-Please read the [full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct)
+Please read the [full text](https://code.fb.com/codeofconduct/)
 so that you can understand what actions will and will not be tolerated.


### PR DESCRIPTION
The prior code of conduct link is no longer accessible. Update here is to presumably correct link.