### PR TITLE
Add gflags headers to tests

### DIFF
--- a/fizz/client/test/ClientSocket.cpp
+++ b/fizz/client/test/ClientSocket.cpp
@@ -8,6 +8,7 @@
 
 #include <fizz/client/AsyncFizzClient.h>
 #include <fizz/crypto/Utils.h>
+#include <folly/portability/GFlags.h>
 #include <folly/ssl/Init.h>
 
 DEFINE_string(host, "localhost", "host to connect to");

--- a/fizz/server/test/ServerSocket.cpp
+++ b/fizz/server/test/ServerSocket.cpp
@@ -12,6 +12,7 @@
 #include <folly/io/async/AsyncSSLSocket.h>
 #include <folly/io/async/AsyncServerSocket.h>
 #include <folly/io/async/SSLContext.h>
+#include <folly/portability/GFlags.h>
 #include <folly/ssl/Init.h>
 
 DEFINE_int32(port, 8443, "port to listen on");

--- a/fizz/test/BogoShim.cpp
+++ b/fizz/test/BogoShim.cpp
@@ -15,6 +15,7 @@
 #include <folly/String.h>
 #include <folly/io/async/AsyncSSLSocket.h>
 #include <folly/io/async/SSLContext.h>
+#include <folly/portability/GFlags.h>
 
 using namespace fizz;
 using namespace fizz::client;


### PR DESCRIPTION
This commit fixes some compilation issues for ClientSocket, ServerSocket
and BogoShim tests due to missing gflags/gflags.h definitions.