### PR TITLE
Adapt fizz OpenSSL hash implementations

### DIFF
--- a/fizz/crypto/Sha-inl.h
+++ b/fizz/crypto/Sha-inl.h
@@ -11,6 +11,26 @@
 namespace fizz {
 
 template <typename T>
+void Sha<T>::hash_init() {
+  digest_.hash_init(T::HashEngine());
+}
+
+template <typename T>
+void Sha<T>::hash_update(folly::ByteRange data) {
+  digest_.hash_update(data);
+}
+
+template <typename T>
+void Sha<T>::hash_update(const folly::IOBuf& data) {
+  digest_.hash_update(data);
+}
+
+template <typename T>
+void Sha<T>::hash_final(folly::MutableByteRange out) {
+  digest_.hash_final(out);
+}
+
+template <typename T>
 void Sha<T>::hmac(
     folly::ByteRange key,
     const folly::IOBuf& in,

--- a/fizz/crypto/Sha.h
+++ b/fizz/crypto/Sha.h
@@ -23,7 +23,16 @@ namespace fizz {
  *   - BlankHash: ByteRange containing the digest of a hash of empty input
  */
 template <typename T>
-struct Sha {
+class Sha {
+ public:
+  void hash_init();
+
+  void hash_update(folly::ByteRange data);
+
+  void hash_update(const folly::IOBuf& data);
+
+  void hash_final(folly::MutableByteRange out);
+
   /**
    * Puts HMAC(key, in) into out. Out must be at least of size HashLen.
    */
@@ -36,6 +45,9 @@ struct Sha {
    * Puts Hash(in) into out. Out must be at least of size HashLen.
    */
   static void hash(const folly::IOBuf& in, folly::MutableByteRange out);
+
+ private:
+  folly::ssl::OpenSSLHash::Digest digest_;
 };
 } // namespace fizz
 #include <fizz/crypto/Sha-inl.h>

--- a/fizz/crypto/Sha256.h
+++ b/fizz/crypto/Sha256.h
@@ -14,7 +14,8 @@
 
 namespace fizz {
 
-struct Sha256 : Sha<Sha256> {
+class Sha256 : public Sha<Sha256> {
+ public:
   static constexpr size_t HashLen = 32;
 
   static constexpr auto HashEngine = EVP_sha256;

--- a/fizz/crypto/Sha384.h
+++ b/fizz/crypto/Sha384.h
@@ -14,7 +14,8 @@
 
 namespace fizz {
 
-struct Sha384 : Sha<Sha384> {
+class Sha384 : public Sha<Sha384> {
+ public:
   static constexpr size_t HashLen = 48;
 
   static constexpr auto HashEngine = EVP_sha384;

--- a/fizz/protocol/HandshakeContext-inl.h
+++ b/fizz/protocol/HandshakeContext-inl.h
@@ -14,8 +14,7 @@ template <typename Hash>
 HandshakeContextImpl<Hash>::HandshakeContextImpl(
     const std::string& hkdfLabelPrefix)
     : hkdfLabelPrefix_(hkdfLabelPrefix) {
-  hashState_ = folly::ssl::OpenSSLHash::Digest();
-  hashState_.hash_init(Hash::HashEngine());
+  hashState_.hash_init();
 }
 
 template <typename Hash>
@@ -25,7 +24,7 @@ void HandshakeContextImpl<Hash>::appendToTranscript(const Buf& data) {
 
 template <typename Hash>
 Buf HandshakeContextImpl<Hash>::getHandshakeContext() const {
-  folly::ssl::OpenSSLHash::Digest copied(hashState_);
+  Hash copied(hashState_);
   auto out = folly::IOBuf::create(Hash::HashLen);
   out->append(Hash::HashLen);
   folly::MutableByteRange outRange(out->writableData(), out->length());

--- a/fizz/protocol/HandshakeContext.h
+++ b/fizz/protocol/HandshakeContext.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <fizz/record/Types.h>
-#include <folly/ssl/OpenSSLHash.h>
 
 namespace fizz {
 
@@ -59,7 +58,7 @@ class HandshakeContextImpl : public HandshakeContext {
   }
 
  private:
-  folly::ssl::OpenSSLHash::Digest hashState_;
+  Hash hashState_;
   std::string hkdfLabelPrefix_;
 };
 } // namespace fizz


### PR DESCRIPTION
Summary: Adapted SHA implementations and removed OpenSSL dependency from HandshakeContext so that HandshakeContext can be used with non-OpenSSL hash implementations.

Reviewed By: knekritz

Differential Revision: D14781837
