### PR TITLE
fix new GCC warnings

### DIFF
--- a/fizz/client/ClientProtocol.cpp
+++ b/fizz/client/ClientProtocol.cpp
@@ -597,7 +597,7 @@ static Optional<EarlyDataParams> getEarlyDataParams(
   params.serverCert = psk->serverCert;
   params.clientCert = psk->clientCert;
   params.alpn = psk->alpn;
-  return std::move(params);
+  return params;
 }
 
 Actions

--- a/fizz/crypto/aead/OpenSSLEVPCipher.cpp
+++ b/fizz/crypto/aead/OpenSSLEVPCipher.cpp
@@ -317,7 +317,7 @@ folly::Optional<std::unique_ptr<folly::IOBuf>> evpDecrypt(
   if (!decrypted) {
     return folly::none;
   }
-  return std::move(output);
+  return output;
 }
 } // namespace detail
 } // namespace fizz

--- a/fizz/extensions/tokenbinding/Types.cpp
+++ b/fizz/extensions/tokenbinding/Types.cpp
@@ -106,7 +106,7 @@ folly::Optional<TokenBindingParameters> getExtension(
   folly::io::Cursor cursor(it->extension_data.get());
   detail::read(params.version, cursor);
   detail::readVector<uint8_t>(params.key_parameters_list, cursor);
-  return std::move(params);
+  return params;
 }
 
 namespace extensions {

--- a/fizz/record/PlaintextRecordLayer.cpp
+++ b/fizz/record/PlaintextRecordLayer.cpp
@@ -88,7 +88,7 @@ folly::Optional<TLSMessage> PlaintextReadRecordLayer::read(
       }
     }
 
-    return std::move(msg);
+    return msg;
   }
 }
 


### PR DESCRIPTION
error: redundant move in return statement [-Werror=redundant-move]