### PR TITLE
Add boost::chrono dependency

### DIFF
--- a/fizz/CMakeLists.txt
+++ b/fizz/CMakeLists.txt
@@ -53,7 +53,7 @@ if (NOT folly_FOUND)
 endif()
 
 find_package(Boost REQUIRED COMPONENTS system thread filesystem regex context
-                                       date_time program_options)
+                                       date_time program_options chrono)
 find_package(OpenSSL REQUIRED)
 find_package(Glog REQUIRED)
 find_package(DoubleConversion REQUIRED)


### PR DESCRIPTION
I'm getting an error saying it's missing.