### PR TITLE
libfmt is a dependency of Folly

### DIFF
--- a/fizz/mac-build.sh
+++ b/fizz/mac-build.sh
@@ -21,6 +21,8 @@ FOLLY_DIR=$DEPS_DIR/folly
 FOLLY_BUILD_DIR=$DEPS_DIR/folly/build/
 FIZZ_BUILD_DIR=$BWD/build
 
+NCPU=$(sysctl -n hw.ncpu || printf 1)
+
 mkdir -p "$FIZZ_BUILD_DIR"
 
 # OpenSSL dirs. If you have OpenSSL installed somewhere
@@ -67,14 +69,14 @@ if [ ! -d "$FOLLY_DIR" ] ; then
 
   # build folly
   git clone https://github.com/facebook/folly.git "$FOLLY_DIR"
-  echo "Building Folly"
+  echo "Building Folly ($NCPU cores)"
   mkdir -p "$FOLLY_BUILD_DIR"
   cd "$FOLLY_BUILD_DIR" || exit
   cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_PREFIX="$FOLLY_INSTALL_DIR" \
     -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR" \
     -DOPENSSL_LIBRARIES="$OPENSSL_LIB_DIR" ..
-  make install
+  make -j${NCPU} install
   cd "$BWD" || exit
 fi
 
@@ -87,7 +89,8 @@ cmake \
   -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR" \
   -DOPENSSL_LIBRARIES="$OPENSSL_LIB_DIR" ../..
 
-make install
+echo "Building Fizz ($NCPU cores)"
+make -j${NCPU} install
 
 rm -rf "${BWD:?}"/bin
 cp -R "$FIZZ_BUILD_DIR"/bin/ "$BWD"/bin/

--- a/fizz/mac-build.sh
+++ b/fizz/mac-build.sh
@@ -43,6 +43,7 @@ if [ ! -d "$FOLLY_DIR" ] ; then
     cmake \
     boost \
     double-conversion \
+    fmt \
     gflags \
     glog \
     libevent \
@@ -56,6 +57,7 @@ if [ ! -d "$FOLLY_DIR" ] ; then
     boost \
     double-conversion \
     gflags \
+    fmt \
     glog \
     libevent \
     lz4 \


### PR DESCRIPTION
The build script mac-build.sh does not install libfmt even though it's a dependency of Folly, resulting in a broken build.  

Fix: Add libfmt to the list of build dependencies.  

