### PR TITLE
Build performance

### DIFF
--- a/fizz/mac-build.sh
+++ b/fizz/mac-build.sh
@@ -21,6 +21,8 @@ FOLLY_DIR=$DEPS_DIR/folly
 FOLLY_BUILD_DIR=$DEPS_DIR/folly/build/
 FIZZ_BUILD_DIR=$BWD/build
 
+NCPU=$(sysctl -n hw.ncpu || printf 1)
+
 mkdir -p "$FIZZ_BUILD_DIR"
 
 # OpenSSL dirs. If you have OpenSSL installed somewhere
@@ -65,14 +67,14 @@ if [ ! -d "$FOLLY_DIR" ] ; then
 
   # build folly
   git clone https://github.com/facebook/folly.git "$FOLLY_DIR"
-  echo "Building Folly"
+  echo "Building Folly ($NCPU cores)"
   mkdir -p "$FOLLY_BUILD_DIR"
   cd "$FOLLY_BUILD_DIR" || exit
   cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_PREFIX="$FOLLY_INSTALL_DIR" \
     -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR" \
     -DOPENSSL_LIBRARIES="$OPENSSL_LIB_DIR" ..
-  make install
+  make -j${NCPU} install
   cd "$BWD" || exit
 fi
 
@@ -85,7 +87,8 @@ cmake \
   -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR" \
   -DOPENSSL_LIBRARIES="$OPENSSL_LIB_DIR" ../..
 
-make install
+echo "Building Fizz ($NCPU cores)"
+make -j${NCPU} install
 
 rm -rf "${BWD:?}"/bin
 cp -R "$FIZZ_BUILD_DIR"/bin/ "$BWD"/bin/


### PR DESCRIPTION
Summary:

Modify `mac-build.sh` to run `make` with -j$NCPU flag, where $NCPU is the number
of cores as reported by macOS.

The speed-up was measured to be x2 on Dual-Core Intel Core i5.

**Details:**

Here are the measured times as reported by the `time` utility: 

```
parallel: sh mac-build.sh  1365.78s user 77.17s system 274% cpu 8:46.22 total
vanilla: sh mac-build.sh  900.69s user 54.79s system 90% cpu 17:34.50 total
```

And here is the output of `system_profiler SPHardwareDataType`:

```
Hardware:

    Hardware Overview:

      Model Name: iMac
      Model Identifier: iMac18,1
      Processor Name: Dual-Core Intel Core i5
      Processor Speed: 2,3 GHz
      Number of Processors: 1
      Total Number of Cores: 2
      L2 Cache (per Core): 256 KB
      L3 Cache: 4 MB
      Hyper-Threading Technology: Enabled
      Memory: 8 GB
      Boot ROM Version: 180.0.0.0.0
      SMC Version (system): 2.39f40
      Serial Number (system): ?
      Hardware UUID: ?
```
