### PR TITLE
Remove undefined bahaviour

### DIFF
--- a/fizz/util/KeyLogWriter.h
+++ b/fizz/util/KeyLogWriter.h
@@ -117,6 +117,8 @@ class KeyLogWriter {
       default:
         break;
     }
+
+    return "";
   }
 
  private:


### PR DESCRIPTION
control reaches end of non-void function warning. In case no label
matches just return an empty string to avoid undefined beahviour.