### PR TITLE
protocol/test: fix handshake secret compare

### DIFF
--- a/fizz/protocol/test/KeySchedulerTest.cpp
+++ b/fizz/protocol/test/KeySchedulerTest.cpp
@@ -200,7 +200,7 @@ TEST_F(KeySchedulerTest, TestClonability) {
   auto t2ch =
       cloned->getSecret(HandshakeSecrets::ClientHandshakeTraffic, transcript2);
   EXPECT_EQ(t1sh, t2sh);
-  EXPECT_EQ(t2ch, t2ch);
+  EXPECT_EQ(t1ch, t2ch);
 }
 
 } // namespace test


### PR DESCRIPTION
There was a comparison between the same variable, instead of comparing the separate secret objects.