### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,22 @@ INSTALL_PREFIX=/usr/local ./mac-build.sh
 
 You might need to run the script as root to install to certain directories.
 
+### Building using vcpkg
+
+Vcpkg helps you manage C and C++ libraries on Windows, Linux and MacOS. 
+You can build and install fizz using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```sh
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+./vcpkg integrate install
+./vcpkg install fizz
+```
+
+The fizz port in vcpkg is kept up to date by Microsoft team members and community contributors. 
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Contributing
 
 We'd love to have your help in making Fizz better. If you're interested, please


### PR DESCRIPTION
Fizz is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for fizz and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build fizz, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/fizz/portfile.cmake). We try to keep the library maintained as close as possible to the original library.