### PR TITLE
fix flaky SlidingBloomReplayCacheTest.cpp

### DIFF
--- a/fizz/server/test/SlidingBloomReplayCacheTest.cpp
+++ b/fizz/server/test/SlidingBloomReplayCacheTest.cpp
@@ -122,7 +122,7 @@ TEST(SlidingBloomReplayCacheTest, TestTimeBucketing) {
     }
   });
 
-  // 0.5 seconds in, all values should still be set
+  // all values should still be set
   folly::via(evb, [&]() {
     evb->schedule(
         [&]() {
@@ -133,7 +133,7 @@ TEST(SlidingBloomReplayCacheTest, TestTimeBucketing) {
         std::chrono::milliseconds(500));
   });
 
-  // 1.5 seconds in, all should be gone.
+  // all should be gone.
   folly::via(evb, [&]() {
     evb->schedule(
         [&]() {
@@ -142,7 +142,7 @@ TEST(SlidingBloomReplayCacheTest, TestTimeBucketing) {
           }
           baton.post();
         },
-        std::chrono::seconds(1));
+        std::chrono::milliseconds(1001));
   });
   baton.wait();
 }


### PR DESCRIPTION
fix flaky SlidingBloomReplayCacheTest.cpp

SlidingBloomReplayCacheTest.cpp test was flaky,  looks like the expiry
can happen at exactly 1 second, moving to 1001 milliseconds fixed it.

Updated associated comments to remove the time periods as was
duplicative of the chrono call just below the comments

Test Plan:

Run locally

```
 ./build/fbcode_builder/getdeps.py build --src-dir=. fizz
 ./build/fbcode_builder/getdeps.py test --src-dir=. fizz
```

before, fails with:
```
[==========] 5 tests from 1 test suite ran. (1115 ms total)
[  PASSED  ] 4 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] SlidingBloomReplayCacheTest.TestTimeBucketing

 1 FAILED TEST
```

after, passes with:
```
100% tests passed, 0 tests failed out of 68

Total Test time (real) =   1.07 sec

```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookincubator/fizz/pull/96).
* #95
* __->__ #96