### PR TITLE
airserver: remove local/shared bundle cleaners and loadgen from OSS/client build

### DIFF
--- a/build/fbcode_builder/manifests/airstore
+++ b/build/fbcode_builder/manifests/airstore
@@ -15,7 +15,6 @@ builder = cmake
 builder = nop
 
 [dependencies]
-boost
 libcurl
 fizz
 fmt


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/openr/pull/149

X-link: https://github.com/facebookincubator/zstrong/pull/609

X-link: https://github.com/facebookincubator/hsthrift/pull/118

X-link: https://github.com/facebookincubator/crux/pull/9

X-link: https://github.com/facebookexperimental/rust-shed/pull/42

X-link: https://github.com/facebook/watchman/pull/1170

X-link: https://github.com/facebook/mvfst/pull/319

X-link: https://github.com/facebook/fbthrift/pull/581

X-link: https://github.com/facebook/fboss/pull/160

X-link: https://github.com/facebook/fb303/pull/41

some cleanup: remove loadgen and bundle cleaners from client build and OSS build - hopefully will let us move faster in these codebases and avoid needing to upkeep the OSS side

Reviewed By: DevSatpathy

Differential Revision:
D50094943

Privacy Context Container: L1091835


