### PR TITLE
Fix build failure with CMake

### DIFF
--- a/fizz/CMakeLists.txt
+++ b/fizz/CMakeLists.txt
@@ -225,6 +225,7 @@ set(FIZZ_SOURCES
   extensions/delegatedcred/DelegatedCredentialCertManager.cpp
   extensions/delegatedcred/DelegatedCredentialClientExtension.cpp
   extensions/delegatedcred/DelegatedCredentialFactory.cpp
+  extensions/delegatedcred/DelegatedCredentialPemUtils.cpp
   extensions/delegatedcred/DelegatedCredentialUtils.cpp
   extensions/delegatedcred/Types.cpp
   extensions/exportedauth/ExportedAuthenticator.cpp


### PR DESCRIPTION
Without this, the build fails with

```
  Undefined symbols for architecture arm64:
    "fizz::extensions::generateDelegatedCredentialPEM(fizz::extensions::DelegatedCredential, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)", referenced from:
        fizz::tool::fizzGenerateDelegatedCredentialCommand(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) in FizzGenerateDelegatedCredentialCommand.cpp.o
  ld: symbol(s) not found for architecture arm64
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This was missed in 19dca4cbe227ad621be1b7bce916840a1b77b12c.

See https://github.com/Homebrew/homebrew-core/actions/runs/8932339958/job/24536092094?pr=170668#step:3:326
