### PR TITLE
Make fizz::ExtensionType compatible with fmt11

### DIFF
--- a/fizz/record/Types.h
+++ b/fizz/record/Types.h
@@ -454,7 +454,7 @@ struct hash<fizz::ExtensionType> {
 
 template <>
 struct fmt::formatter<fizz::ExtensionType> : formatter<unsigned> {
-  auto format(fizz::ExtensionType t, format_context& ctx) {
+  auto format(fizz::ExtensionType t, format_context& ctx) const {
     return formatter<unsigned>::format(folly::to_underlying(t), ctx);
   }
 };


### PR DESCRIPTION
starting from [fmt11.0.0](https://github.com/fmtlib/fmt/issues/3447), fmt requires formatter::format to be const.
> Started enforcing that formatter::format is const for compatibility with std::format