### PR TITLE
make openssl install less confusing, align openssl version

### DIFF
--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -333,6 +333,12 @@ class FetchCmd(ProjectCmdBase):
 
         cache = cache_module.create_cache()
         for m in projects:
+            fetcher = loader.create_fetcher(m)
+            if isinstance(fetcher, SystemPackageFetcher):
+                # We are guaranteed that if the fetcher is set to
+                # SystemPackageFetcher then this item is completely
+                # satisfied by the appropriate system packages
+                continue
             cached_project = CachedProject(cache, loader, m)
             if cached_project.download():
                 continue
@@ -348,7 +354,6 @@ class FetchCmd(ProjectCmdBase):
                     continue
 
             # We need to fetch the sources
-            fetcher = loader.create_fetcher(m)
             fetcher.update()
 
 

--- a/build/fbcode_builder/manifests/openssl
+++ b/build/fbcode_builder/manifests/openssl
@@ -5,7 +5,7 @@ name = openssl
 libssl-dev
 
 [homebrew]
-openssl@1.1
+openssl
 # on homebrew need the matching curl and ca-
 
 [rpms]
@@ -16,9 +16,11 @@ openssl-libs
 [pps]
 openssl
 
-[download]
-url = https://www.openssl.org/source/openssl-1.1.1l.tar.gz
-sha256 = 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
+# no need to download on the systems where we always use the system libs
+[download.not(any(os=linux, os=freebsd))]
+# match the openssl version packages in ubuntu LTS folly current supports
+url = https://www.openssl.org/source/openssl-3.0.15.tar.gz
+sha256 = 23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533
 
 # We use the system openssl on these platforms even without --allow-system-packages
 [build.any(os=linux, os=freebsd)]
@@ -26,7 +28,7 @@ builder = nop
 
 [build.not(any(os=linux, os=freebsd))]
 builder = openssl
-subdir = openssl-1.1.1l
+subdir = openssl-3.0.15
 
 [dependencies.os=windows]
 perl


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/zstrong/pull/1073

On linux getdeps uses system openssl,  on macOS we mostly use the homebrew one on github CI. Both of these are openssl3.x,  however the fallback build from source version is still set as openssl1.1.  This can be confusing, giving the impression getdeps based builds need openssl1.1
* Update the openssl manifest source url to openssl-3.0.15,  this version picked to match the ubuntu 22.04 LTS system packages.

The other potentially confusing part was that the openssl source tarball was downloaded even when on on a platform like Linux where openssl is always taken from the system packages.
* Make the download configurable so that does nothing if satisified from system packages.

Reviewed By: ckwalsh

Differential Revision: D66495352


