### PR TITLE
fix: resolve ambiguous reference to gflags in BogoShim.cpp

### DIFF
--- a/fizz/test/BogoShim.cpp
+++ b/fizz/test/BogoShim.cpp
@@ -393,7 +393,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   google::InitGoogleLogging(argv[0]);
   CryptoUtils::init();
 


### PR DESCRIPTION
While building fizz 2024.12.02.00, seeing build failure as

```
  /tmp/fizz-20241202-25134-jrbd7f/fizz/test/BogoShim.cpp:396:3: error: reference to 'gflags' is ambiguous
    396 |   gflags::ParseCommandLineFlags(&argc, &argv, true);
        |   ^
  /opt/homebrew/include/gflags/gflags_gflags.h:41:11: note: candidate found by name lookup is 'gflags'
     41 | namespace gflags {
        |           ^
  /opt/homebrew/include/folly/portability/GFlags.h:124:11: note: candidate found by name lookup is 'folly::gflags'
    124 | namespace gflags = ::GFLAGS_NAMESPACE;
        |           ^
  1 error generated.
```

relates to https://github.com/Homebrew/homebrew-core/pull/199768