### PR TITLE
Fix for folly gflags portability commit 3729257

### DIFF
--- a/fizz/test/BogoShim.cpp
+++ b/fizz/test/BogoShim.cpp
@@ -393,7 +393,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  folly::gflags::ParseCommandLineFlags(&argc, &argv, true);
   google::InitGoogleLogging(argv[0]);
   CryptoUtils::init();
 


### PR DESCRIPTION
Refactor gflags:: -> folly::gflags:: per folly commit 3729257
