### PR TITLE
fix test execution when building OSS repo with tpx on path

### DIFF
--- a/build/fbcode_builder/getdeps/builder.py
+++ b/build/fbcode_builder/getdeps/builder.py
@@ -979,12 +979,18 @@ if __name__ == "__main__":
             # better signals for flaky tests.
             retry = 0
 
-        tpx = path_search(env, "tpx")
+        tpx = None
+        try:
+            from .facebook.testinfra import start_run
+
+            tpx = path_search(env, "tpx")
+        except ImportError:
+            # internal testinfra not available
+            pass
+
         if tpx and not no_testpilot:
             buck_test_info = list_tests()
             import os
-
-            from .facebook.testinfra import start_run
 
             buck_test_info_name = os.path.join(self.build_dir, ".buck-test-info.json")
             with open(buck_test_info_name, "w") as f:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/zstrong/pull/1192

Fix case when testing a github repo checkout, wth tpx on path, where --no-testpilot not specified.

As workaround before this lands, if in this situation pass --no-testpilot

Reviewed By: bigfootjon

Differential Revision: D69852662


