### PR TITLE
getdeps: update github windows runner and internal CI to VS 2022

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -501,12 +501,12 @@ jobs:
        path: ${{ steps.paths.outputs.folly_INSTALL }}
        key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
     - name: Build fizz
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. fizz  --project-install-prefix fizz:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. fizz --project-install-prefix fizz:/usr/local
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --strip --src-dir=. fizz _artifacts/linux  --project-install-prefix fizz:/usr/local --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --strip --src-dir=. fizz _artifacts/linux --project-install-prefix fizz:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@v4
       with:
         name: fizz
         path: _artifacts
     - name: Test fizz
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. fizz  --project-install-prefix fizz:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. fizz --project-install-prefix fizz:/usr/local

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -461,12 +461,12 @@ jobs:
        path: ${{ steps.paths.outputs.folly_INSTALL }}
        key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
     - name: Build fizz
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. fizz  --project-install-prefix fizz:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. fizz --project-install-prefix fizz:/usr/local
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. fizz _artifacts/mac  --project-install-prefix fizz:/usr/local --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. fizz _artifacts/mac --project-install-prefix fizz:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@v4
       with:
         name: fizz
         path: _artifacts
     - name: Test fizz
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. fizz  --project-install-prefix fizz:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. fizz --project-install-prefix fizz:/usr/local

--- a/.github/workflows/getdeps_windows.yml
+++ b/.github/workflows/getdeps_windows.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - name: Export boost environment
       run: "echo BOOST_ROOT=%BOOST_ROOT_1_83_0% >> %GITHUB_ENV%"
@@ -431,12 +431,12 @@ jobs:
        path: ${{ steps.paths.outputs.liboqs_INSTALL }}
        key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
     - name: Build fizz
-      run: python build/fbcode_builder/getdeps.py build --src-dir=. fizz 
+      run: python build/fbcode_builder/getdeps.py build --src-dir=. fizz
     - name: Copy artifacts
-      run: python build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. fizz _artifacts/windows  --final-install-prefix /usr/local
+      run: python build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. fizz _artifacts/windows --final-install-prefix /usr/local
     - uses: actions/upload-artifact@v4
       with:
         name: fizz
         path: _artifacts
     - name: Test fizz
-      run: python build/fbcode_builder/getdeps.py test --src-dir=. fizz 
+      run: python build/fbcode_builder/getdeps.py test --src-dir=. fizz

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -1015,6 +1015,8 @@ class GenerateGitHubActionsCmd(ProjectCmdBase):
         if args.cron:
             if args.cron == "never":
                 return " {}"
+            elif args.cron == "workflow_dispatch":
+                return "\n  workflow_dispatch"
             else:
                 return f"""
   schedule:
@@ -1082,7 +1084,7 @@ class GenerateGitHubActionsCmd(ProjectCmdBase):
             if args.runs_on:
                 runs_on = args.runs_on
             else:
-                runs_on = "windows-2019"
+                runs_on = "windows-2022"
             # The windows runners are python 3 by default; python2.exe
             # is available if needed.
             py3 = "python"
@@ -1324,7 +1326,7 @@ jobs:
                 no_deps_arg = "--no-deps "
 
             out.write(
-                f"      run: {getdepscmd}{allow_sys_arg} build {build_type_arg}{tests_arg}{no_deps_arg}--src-dir=. {manifest.name} {project_prefix}\n"
+                f"      run: {getdepscmd}{allow_sys_arg} build {build_type_arg}{tests_arg}{no_deps_arg}--src-dir=. {manifest.name}{project_prefix}\n"
             )
 
             out.write("    - name: Copy artifacts\n")
@@ -1339,7 +1341,7 @@ jobs:
 
             out.write(
                 f"      run: {getdepscmd}{allow_sys_arg} fixup-dyn-deps{strip} "
-                f"--src-dir=. {manifest.name} _artifacts/{artifacts} {project_prefix} "
+                f"--src-dir=. {manifest.name} _artifacts/{artifacts}{project_prefix} "
                 f"--final-install-prefix /usr/local\n"
             )
 
@@ -1355,7 +1357,7 @@ jobs:
 
                 out.write("    - name: Test %s\n" % manifest.name)
                 out.write(
-                    f"      run: {getdepscmd}{allow_sys_arg} test {num_jobs_arg}--src-dir=. {manifest.name} {project_prefix}\n"
+                    f"      run: {getdepscmd}{allow_sys_arg} test {num_jobs_arg}--src-dir=. {manifest.name}{project_prefix}\n"
                 )
             if build_opts.free_up_disk and not build_opts.is_windows():
                 out.write("    - name: Show disk space at end\n")

--- a/build/fbcode_builder/getdeps/buildopts.py
+++ b/build/fbcode_builder/getdeps/buildopts.py
@@ -147,25 +147,43 @@ class BuildOptions(object):
             # On Windows, the compiler is not available in the PATH by
             # default so we need to run the vcvarsall script to populate the
             # environment. We use a glob to find some version of this script
-            # as deployed with Visual Studio 2017.  This logic can also
-            # locate Visual Studio 2019 but note that at the time of writing
-            # the version of boost in our manifest cannot be built with
-            # VS 2019, so we're effectively tied to VS 2017 until we upgrade
-            # the boost dependency.
-            for year in ["2017", "2019"]:
-                vcvarsall += glob.glob(
-                    os.path.join(
-                        os.environ["ProgramFiles(x86)"],
-                        "Microsoft Visual Studio",
-                        year,
-                        "*",
-                        "VC",
-                        "Auxiliary",
-                        "Build",
-                        "vcvarsall.bat",
+            # as deployed with Visual Studio.
+            if len(vcvarsall) == 0:
+                # check the 64 bit installs
+                for year in ["2022"]:
+                    vcvarsall += glob.glob(
+                        os.path.join(
+                            os.environ.get("ProgramFiles", "C:\\Program Files"),
+                            "Microsoft Visual Studio",
+                            year,
+                            "*",
+                            "VC",
+                            "Auxiliary",
+                            "Build",
+                            "vcvarsall.bat",
+                        )
                     )
+
+                # then the 32 bit ones
+                for year in ["2019", "2017"]:
+                    vcvarsall += glob.glob(
+                        os.path.join(
+                            os.environ["ProgramFiles(x86)"],
+                            "Microsoft Visual Studio",
+                            year,
+                            "*",
+                            "VC",
+                            "Auxiliary",
+                            "Build",
+                            "vcvarsall.bat",
+                        )
+                    )
+            if len(vcvarsall) == 0:
+                raise Exception(
+                    "Could not find vcvarsall.bat. Please install Visual Studio."
                 )
             vcvars_path = vcvarsall[0]
+            print(f"Using vcvarsall.bat from {vcvars_path}", file=sys.stderr)
 
         self.vcvars_path = vcvars_path
 

--- a/build/fbcode_builder/getdeps/dyndeps.py
+++ b/build/fbcode_builder/getdeps/dyndeps.py
@@ -177,6 +177,12 @@ class WinDeps(DepBase):
         # The registry option to find the install dir doesn't work anymore.
         globs = [
             (
+                "C:/Program Files/"
+                "Microsoft Visual Studio/"
+                "*/*/VC/Tools/"
+                "MSVC/*/bin/Hostx64/x64/dumpbin.exe"
+            ),
+            (
                 "C:/Program Files (x86)/"
                 "Microsoft Visual Studio/"
                 "*/*/VC/Tools/"

--- a/build/fbcode_builder/manifests/boost
+++ b/build/fbcode_builder/manifests/boost
@@ -113,4 +113,4 @@ toolset=clang
 cxxflags="-DBOOST_UNORDERED_HAVE_PIECEWISE_CONSTRUCT=0"
 
 [b2.args.all(os=windows,fb=on)]
-toolset=msvc-14.2
+toolset=msvc-14.3


### PR DESCRIPTION
Summary:
The github [windows-2019 actions image was retired by github](https://github.com/actions/runner-images/issues/12045),  so all jobs on it fail

Update to windows-2022 to get them running again

windows-2022 has [different tools and versions than windows-2019](https://github.com/actions/runner-images/issues/3949).  Notably it moves from Visual Studio 2019 (aka msvc 16.x) to Visual Studio 2022 (aka msvc 17.x), hence the update to buildopts.py discovery

In the course of regenerating the github actions I also fixed a couple of issues that stopped regeneration matching repo contents
  * a few workflows were using workflow_dispatch, added support
  * there were a trailing and double spaces for project_prefix, fixed (use ignore whitespace to remove this from review!)

Differential Revision: D78019509


