### PR TITLE
Allow overwriting module paths for HHVM OSS

### DIFF
--- a/fizz/CMakeLists.txt
+++ b/fizz/CMakeLists.txt
@@ -3,6 +3,13 @@
 
 cmake_minimum_required(VERSION 3.5)
 
+# Support: HHVM OSS
+# HHVM needs to supply overrides for some module search paths
+# to use vendored equivalents of system dependencies.
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 if (NOT DEFINED PACKAGE_VERSION)
   set(PACKAGE_VERSION "1.0.0")
 endif()


### PR DESCRIPTION
HHVM OSS[1] mirrors its Meta first-party library dependencies via shipit and consumes them via `ExternalProject` so that it can be built as a single CMake project. It also vendors a number of third-party library dependencies such as gflags and glog that are also dependencies of these first-party library dependencies. It currently tries to ensure that the glog include directories and link libraries used when compiling and linking folly point to the vendored glog by setting `GLOG_INCLUDEDIR` / `GLOG_LIBRARY` which are forwarded to `find_library` and co. by FindGlog.cmake, but this doesn't work because `find_library` and co. only consider these hint paths after system default paths have been searched, so the system glog (if any) would end up being preferred.

So, explicitly opt into CMP0074[2] to allow HHVM to simply set `Glog_ROOT` to override the glog search paths. Alternatively, we could also raise the required CMake version to 3.12 (released in 2018) or newer to get the NEW behavior by default. fbthrift has recently started requiring 3.20.2.

[1] https://github.com/facebook/hhvm
[2] https://cmake.org/cmake/help/latest/policy/CMP0074.html