### PR TITLE
CMakeLists.txt FetchContent compatibility

### DIFF
--- a/fizz/CMakeLists.txt
+++ b/fizz/CMakeLists.txt
@@ -9,6 +9,10 @@ endif()
 
 project("fizz" VERSION ${PACKAGE_VERSION} LANGUAGES CXX C)
 
+# Set for FetchContent to skip find_package(fizz)
+set(fizz_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+  CACHE INTERNAL "fizz source directory")
+
 if (NOT DEFINED CPACK_GENERATOR)
   set(CPACK_GENERATOR "RPM")
 endif()
@@ -49,7 +53,10 @@ set(BIN_INSTALL_DIR bin CACHE STRING
 set(CMAKE_INSTALL_DIR lib/cmake/fizz CACHE STRING
     "The subdirectory where CMake package config files should be installed")
 
-find_package(folly CONFIG REQUIRED)
+# If folly is being built from source (FetchContent), skip find_package
+if (NOT DEFINED folly_SOURCE_DIR)
+  find_package(folly CONFIG REQUIRED)
+endif()
 find_package(fmt CONFIG REQUIRED)
 
 find_package(OpenSSL REQUIRED)
@@ -187,13 +194,14 @@ endforeach()
 add_library(fizz
   ${FIZZ_LIBRARY_SOURCES}
 )
+add_library(fizz::fizz ALIAS fizz)
 
 if (BUILD_SHARED_LIBS)
   set_target_properties(fizz
     PROPERTIES VERSION ${PACKAGE_VERSION})
 endif()
 
-get_filename_component(FIZZ_BASE_DIR ${CMAKE_SOURCE_DIR}/.. ABSOLUTE)
+get_filename_component(FIZZ_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/.. ABSOLUTE)
 
 target_include_directories(
   fizz


### PR DESCRIPTION
Summary:
When fizz is consumed via FetchContent, CMAKE_SOURCE_DIR points to the top-level project rather than fizz itself, and folly is built in-tree rather than installed. This diff makes three fixes:

1. Set fizz_SOURCE_DIR as a cache variable so downstream FetchContent consumers can skip find_package(fizz)
2. Guard find_package(folly) behind a check for folly_SOURCE_DIR, allowing folly to be built from source in the same CMake tree
3. Use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR for FIZZ_BASE_DIR so the path is correct when fizz is a subdirectory

Differential Revision: D93366451


